### PR TITLE
Hotfix - Update pyOpenSSL dependency to be compatible with new cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==41.0.2
-pyOpenSSL==22.0.0
+pyOpenSSL==23.2.0
 requests==2.28.1
 requests-toolbelt==1.0.0
 boto3==1.24.28


### PR DESCRIPTION
If you are using cryptography and pyOpenSSL, you must be sure that pyOpenSSL is compatible with your new cryptography version: https://github.com/pyca/pyopenssl/blob/23.2.0/setup.py#L102