### PR TITLE
Cumulus 16 support

### DIFF
--- a/cumulus_api/main.py
+++ b/cumulus_api/main.py
@@ -33,7 +33,10 @@ class CumulusApi:
         self.INVOKE_BASE_URL = self.config["INVOKE_BASE_URL"].rstrip('/')
         self.cumulus_token = CumulusToken(config=config)
         self.TOKEN = token if token else self.cumulus_token.get_token()
-        self.HEADERS = {'Authorization': f'Bearer {self.TOKEN}'}
+        self.HEADERS = {
+            'Authorization': f'Bearer {self.TOKEN}',
+            'Cumulus-API-Version': '2',
+        }
 
     def __crud_records(self, record_type, verb, data=None, **kwargs):
         """
@@ -131,7 +134,7 @@ class CumulusApi:
         :return: message of success or raise error
         """
         record_type = f"providers/{data['id']}"
-        return self.__crud_records(record_type=record_type, verb="put", data=data)
+        return self.__crud_records(record_type=record_type, verb="patch", data=data)
 
     def delete_provider(self, provider_id):
         """
@@ -190,7 +193,7 @@ class CumulusApi:
         :return:
         """
         record_type = f"collections/{data['name']}/{data['version']}"
-        return self.__crud_records(record_type=record_type, verb="put", data=data)
+        return self.__crud_records(record_type=record_type, verb="patch", data=data)
 
     def delete_collection(self, collection_name, collection_version):
         """
@@ -263,7 +266,7 @@ class CumulusApi:
         record_type = f"granules/{granule_id}"
         data = {} if data is None else data
         data.update({"action": "reingest"})
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def apply_workflow_to_granule(self, granule_id, workflow_name):
         """
@@ -275,7 +278,7 @@ class CumulusApi:
         """
         record_type = f"granules/{granule_id}"
         data = {"action": "applyWorkflow", "workflow": workflow_name}
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def move_granule(self, granule_id, regex, bucket, file_path):
         """
@@ -290,7 +293,7 @@ class CumulusApi:
         record_type = f"granules/{granule_id}"
         data = {"action": "move",
                 "destinations": [{"regex": regex, "bucket": bucket, "filepath": file_path}]}
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def remove_granule_from_cmr(self, granule_id):
         """
@@ -300,7 +303,7 @@ class CumulusApi:
         """
         record_type = f"granules/{granule_id}"
         data = {"action": "removeFromCmr"}
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def delete_granule(self, granule_id):
         """
@@ -406,7 +409,7 @@ class CumulusApi:
         :return: Returns a mapping of the updated properties.
         """
         record_type = f"rules/{data['name']}"
-        return self.__crud_records(record_type=record_type, verb="put", data=data)
+        return self.__crud_records(record_type=record_type, verb="patch", data=data)
 
     def delete_rule(self, rule_name):
         """
@@ -425,7 +428,7 @@ class CumulusApi:
         """
         record_type = f"rules/{rule_name}"
         data = {"name": rule_name, "action": "rerun"}
-        return self.__crud_records(record_type=record_type, verb="put", data=data)
+        return self.__crud_records(record_type=record_type, verb="patch", data=data)
 
     # ============== Stats ===============
 
@@ -539,7 +542,7 @@ class CumulusApi:
         :return: Request response
         """
         record_type = f"executions/{data['arn']}"
-        return self.__crud_records(record_type=record_type, verb="put", data=data)
+        return self.__crud_records(record_type=record_type, verb="patch", data=data)
 
     def delete_execution(self, execution_arn):
         """
@@ -683,7 +686,7 @@ class CumulusApi:
         :return: Request response
         """
         record_type = "elasticsearch/change-index"
-        return self.__crud_records(record_type=record_type, verb="put", data=data)
+        return self.__crud_records(record_type=record_type, verb="patch", data=data)
 
     def reindex_elasticsearh_from_database(self, **kwargs):
         """

--- a/cumulus_api/main.py
+++ b/cumulus_api/main.py
@@ -33,7 +33,10 @@ class CumulusApi:
         self.INVOKE_BASE_URL = self.config["INVOKE_BASE_URL"].rstrip('/')
         self.cumulus_token = CumulusToken(config=config)
         self.TOKEN = token if token else self.cumulus_token.get_token()
-        self.HEADERS = {'Authorization': f'Bearer {self.TOKEN}'}
+        self.HEADERS = {
+            'Authorization': f'Bearer {self.TOKEN}',
+            'Cumulus-API-Version': '2',
+        }
 
     def __crud_records(self, record_type, verb, data=None, **kwargs):
         """
@@ -79,7 +82,10 @@ class CumulusApi:
         # data = {"token": self.TOKEN}
         # refreshed_token = self.__crud_records(record_type="refresh", verb="post", data=data)
         self.TOKEN = self.cumulus_token.get_token()
-        self.HEADERS = {'Authorization': f'Bearer {self.TOKEN}'}
+        self.HEADERS = {
+            'Authorization': f'Bearer {self.TOKEN}',
+            'Cumulus-API-Version': '2',
+        }
 
         # refreshed_token.get('token')
         return True
@@ -263,7 +269,7 @@ class CumulusApi:
         record_type = f"granules/{granule_id}"
         data = {} if data is None else data
         data.update({"action": "reingest"})
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def apply_workflow_to_granule(self, granule_id, workflow_name):
         """
@@ -275,7 +281,7 @@ class CumulusApi:
         """
         record_type = f"granules/{granule_id}"
         data = {"action": "applyWorkflow", "workflow": workflow_name}
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def move_granule(self, granule_id, regex, bucket, file_path):
         """
@@ -290,7 +296,7 @@ class CumulusApi:
         record_type = f"granules/{granule_id}"
         data = {"action": "move",
                 "destinations": [{"regex": regex, "bucket": bucket, "filepath": file_path}]}
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def remove_granule_from_cmr(self, granule_id):
         """
@@ -300,7 +306,7 @@ class CumulusApi:
         """
         record_type = f"granules/{granule_id}"
         data = {"action": "removeFromCmr"}
-        return self.__crud_records(record_type=record_type, data=data, verb="put")
+        return self.__crud_records(record_type=record_type, data=data, verb="patch")
 
     def delete_granule(self, granule_id):
         """

--- a/cumulus_api/main.py
+++ b/cumulus_api/main.py
@@ -33,10 +33,7 @@ class CumulusApi:
         self.INVOKE_BASE_URL = self.config["INVOKE_BASE_URL"].rstrip('/')
         self.cumulus_token = CumulusToken(config=config)
         self.TOKEN = token if token else self.cumulus_token.get_token()
-        self.HEADERS = {
-            'Authorization': f'Bearer {self.TOKEN}',
-            'Cumulus-API-Version': '2',
-        }
+        self.HEADERS = {'Authorization': f'Bearer {self.TOKEN}'}
 
     def __crud_records(self, record_type, verb, data=None, **kwargs):
         """
@@ -134,7 +131,7 @@ class CumulusApi:
         :return: message of success or raise error
         """
         record_type = f"providers/{data['id']}"
-        return self.__crud_records(record_type=record_type, verb="patch", data=data)
+        return self.__crud_records(record_type=record_type, verb="put", data=data)
 
     def delete_provider(self, provider_id):
         """
@@ -193,7 +190,7 @@ class CumulusApi:
         :return:
         """
         record_type = f"collections/{data['name']}/{data['version']}"
-        return self.__crud_records(record_type=record_type, verb="patch", data=data)
+        return self.__crud_records(record_type=record_type, verb="put", data=data)
 
     def delete_collection(self, collection_name, collection_version):
         """
@@ -266,7 +263,7 @@ class CumulusApi:
         record_type = f"granules/{granule_id}"
         data = {} if data is None else data
         data.update({"action": "reingest"})
-        return self.__crud_records(record_type=record_type, data=data, verb="patch")
+        return self.__crud_records(record_type=record_type, data=data, verb="put")
 
     def apply_workflow_to_granule(self, granule_id, workflow_name):
         """
@@ -278,7 +275,7 @@ class CumulusApi:
         """
         record_type = f"granules/{granule_id}"
         data = {"action": "applyWorkflow", "workflow": workflow_name}
-        return self.__crud_records(record_type=record_type, data=data, verb="patch")
+        return self.__crud_records(record_type=record_type, data=data, verb="put")
 
     def move_granule(self, granule_id, regex, bucket, file_path):
         """
@@ -293,7 +290,7 @@ class CumulusApi:
         record_type = f"granules/{granule_id}"
         data = {"action": "move",
                 "destinations": [{"regex": regex, "bucket": bucket, "filepath": file_path}]}
-        return self.__crud_records(record_type=record_type, data=data, verb="patch")
+        return self.__crud_records(record_type=record_type, data=data, verb="put")
 
     def remove_granule_from_cmr(self, granule_id):
         """
@@ -303,7 +300,7 @@ class CumulusApi:
         """
         record_type = f"granules/{granule_id}"
         data = {"action": "removeFromCmr"}
-        return self.__crud_records(record_type=record_type, data=data, verb="patch")
+        return self.__crud_records(record_type=record_type, data=data, verb="put")
 
     def delete_granule(self, granule_id):
         """
@@ -409,7 +406,7 @@ class CumulusApi:
         :return: Returns a mapping of the updated properties.
         """
         record_type = f"rules/{data['name']}"
-        return self.__crud_records(record_type=record_type, verb="patch", data=data)
+        return self.__crud_records(record_type=record_type, verb="put", data=data)
 
     def delete_rule(self, rule_name):
         """
@@ -428,7 +425,7 @@ class CumulusApi:
         """
         record_type = f"rules/{rule_name}"
         data = {"name": rule_name, "action": "rerun"}
-        return self.__crud_records(record_type=record_type, verb="patch", data=data)
+        return self.__crud_records(record_type=record_type, verb="put", data=data)
 
     # ============== Stats ===============
 
@@ -542,7 +539,7 @@ class CumulusApi:
         :return: Request response
         """
         record_type = f"executions/{data['arn']}"
-        return self.__crud_records(record_type=record_type, verb="patch", data=data)
+        return self.__crud_records(record_type=record_type, verb="put", data=data)
 
     def delete_execution(self, execution_arn):
         """
@@ -686,7 +683,7 @@ class CumulusApi:
         :return: Request response
         """
         record_type = "elasticsearch/change-index"
-        return self.__crud_records(record_type=record_type, verb="patch", data=data)
+        return self.__crud_records(record_type=record_type, verb="put", data=data)
 
     def reindex_elasticsearh_from_database(self, **kwargs):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==41.0.2
-pyOpenSSL==22.0.0
+pyOpenSSL==23.2.0
 requests==2.28.1
 requests-toolbelt==1.0.0
 boto3==1.24.28


### PR DESCRIPTION
NSIDC has a need to work with cumulus-api in a Cumulus 16 environment. Between Cumulus 15 and 16 there are some breaking changes involving existing `granules` PUT endpoints. PUT was deprecated in favor of PATCH for existing functionality, with plans for PUT behavior to transition to fully overwriting the target. There was also a requirement added 
to provide a version header with these requests.

These changes have been implemented in an NSIDC fork of the repository, and we are providing the corresponding PR should it be useful for any updates you have planned for the next PI.